### PR TITLE
fix: restore CI build broken by TypeScript 6.0 (XEO-717)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,16 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     groups:
-      all:
-        patterns: 
+      patch-and-minor:
+        patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
     schedule:
       interval: "monthly"

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 
 src/*.js
+
+# Git worktrees
+.worktrees/

--- a/docs/superpowers/specs/2026-06-15-typescript-6-node-types-fix-design.md
+++ b/docs/superpowers/specs/2026-06-15-typescript-6-node-types-fix-design.md
@@ -1,0 +1,24 @@
+# Fix TypeScript 6.0 Node Type Globals (XEO-717)
+
+## Problem
+
+Dependabot auto-merged a major TypeScript bump (5.9.3 → 6.0.3) alongside minor/patch updates. TypeScript 6.0 no longer auto-includes `@types/node` globals — `process`, `console`, etc. are now absent because `@types/node` is only a transitive dependency and isn't declared in `tsconfig.json`. The CI workflow fails at the `npm run build` step with `TS2591`/`TS2584` errors.
+
+## Fix
+
+### 1. Add `@types/node` as a dev dependency
+
+Install `@types/node@^22` (matching the Node 22 runtime declared in `.nvmrc`). This makes the dependency explicit rather than relying on a transitive install from `ts-node`.
+
+### 2. Declare node types in `tsconfig.json`
+
+Add `"types": ["node"]` to `compilerOptions`. This is the TypeScript 6 way to opt in to Node.js global type augmentations.
+
+### 3. Separate major-version bumps in dependabot
+
+Update `.github/dependabot.yml` to put major-version npm updates in a dedicated group with `update-types: ["minor", "patch"]` on the existing auto-merge group, so future major bumps create separate PRs that require manual review rather than auto-merging.
+
+## Out of Scope
+
+- No source code changes needed; the errors are purely type-declaration gaps.
+- No changes to the workflow YAML.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "octokit": "^5.0.5",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3"
+      },
+      "devDependencies": {
+        "@types/node": "^22.19.21"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -404,10 +407,12 @@
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.1.tgz",
-      "integrity": "sha512-GKX1Qnqxo4S+Z/+Z8KKPLpH282LD7jLHWJcVryOflnsnH+BtSDfieR6ObwBMwpnNws0bUK8GI7z0unQf9bARNQ==",
-      "peer": true
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.8.0",
@@ -884,6 +889,11 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
@@ -1209,10 +1219,12 @@
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="
     },
     "@types/node": {
-      "version": "18.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.1.tgz",
-      "integrity": "sha512-GKX1Qnqxo4S+Z/+Z8KKPLpH282LD7jLHWJcVryOflnsnH+BtSDfieR6ObwBMwpnNws0bUK8GI7z0unQf9bARNQ==",
-      "peer": true
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "acorn": {
       "version": "8.8.0",
@@ -1525,6 +1537,11 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "universal-github-app-jwt": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "octokit": "^5.0.5",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.21"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,7 @@
       // different options with a single tsconfig.json.
     }
   },
-  "compilerOptions": {}
+  "compilerOptions": {
+    "types": ["node"]
+  }
 }


### PR DESCRIPTION
## Summary

- Add `@types/node@^22` as explicit dev dependency (previously only transitive via `ts-node`)
- Add `"types": ["node"]` to `tsconfig.json` — required in TypeScript 6.0, which no longer auto-includes Node globals
- Split dependabot groups so major npm version bumps get their own PR instead of auto-merging with minor/patch

## Root Cause

Dependabot auto-merged TypeScript 5.9.3 → 6.0.3 alongside minor updates. TypeScript 6.0 is a breaking change: `process`, `console`, and other Node globals are no longer available unless `@types/node` is explicitly declared in `tsconfig.json`'s `types` field.

## Test Plan

- [ ] CI workflow `Sync GitHub stars with Raindrop` passes on this branch
- [ ] `npm ci && npm run build` exits 0 locally
- [ ] Future major version bumps from dependabot appear as separate PRs

Fixes XEO-717

🤖 Generated with [Claude Code](https://claude.com/claude-code)