### PR TITLE
chore: add GitHub Actions to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
           - "major"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary
- Adds `github-actions` ecosystem to the Dependabot configuration so action versions in `.github/workflows/` are kept up to date automatically
- Uses the same monthly schedule as the existing npm updates

## Test plan
- [ ] Verify Dependabot picks up the new config after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)