### PR TITLE
feat: add Vitest test suite with unit and integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: "Tests"
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/docs/superpowers/plans/2026-06-16-test-suite.md
+++ b/docs/superpowers/plans/2026-06-16-test-suite.md
@@ -1,0 +1,598 @@
+# Test Suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Vitest-based test suite with unit and integration tests for `src/main.ts`, wired into GitHub Actions CI.
+
+**Architecture:** Extract two pure functions (`mapStarToRaindrop`, `filterNewRaindrops`) and shared types from `main()` so they can be unit-tested in isolation. Write integration tests that mock axios and Octokit to exercise the full `main()` flow without touching real APIs. Add a separate CI workflow that runs tests on every push/PR.
+
+**Tech Stack:** Vitest, TypeScript, ESM modules (`"type": "module"`), GitHub Actions
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `package.json` | Add `vitest` dev dep, add `"test"` script |
+| Modify | `src/main.ts` | Export types `StarredRepo`, `ActualStar`, `RaindropItem`; extract and export `mapStarToRaindrop` and `filterNewRaindrops`; update `main()` call sites |
+| Create | `src/__tests__/main.unit.test.ts` | Unit tests for the two pure functions |
+| Create | `src/__tests__/main.integration.test.ts` | Integration tests for `main()` with mocked APIs |
+| Create | `.github/workflows/test.yml` | CI workflow: runs `npm test` on push and PR |
+
+---
+
+## Task 1: Install Vitest
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install vitest as a dev dependency**
+
+```bash
+npm install --save-dev vitest
+```
+
+Expected: `package.json` now has `"vitest"` under `devDependencies`.
+
+- [ ] **Step 2: Add the test script to `package.json`**
+
+In `package.json`, add `"test"` to the `scripts` section:
+
+```json
+{
+  "scripts": {
+    "start": "node src/index.js",
+    "build": "tsc -p .",
+    "typecheck": "tsc -p . --noEmit",
+    "clean": "rm src/*.js",
+    "docker": "npm install && npm run build && docker compose up -d",
+    "test": "vitest run"
+  }
+}
+```
+
+- [ ] **Step 3: Verify Vitest runs (no tests yet)**
+
+```bash
+npm test
+```
+
+Expected output includes something like `No test files found` or exits cleanly with 0 test files. If it errors, check the `package.json` change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: install vitest"
+```
+
+---
+
+## Task 2: Unit tests for `mapStarToRaindrop` (TDD)
+
+**Files:**
+- Create: `src/__tests__/main.unit.test.ts`
+- Modify: `src/main.ts`
+
+### Step 2a: Write the failing tests
+
+- [ ] **Step 1: Create `src/__tests__/main.unit.test.ts` with tests for `mapStarToRaindrop`**
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { mapStarToRaindrop } from '../main.js'
+import type { ActualStar } from '../main.js'
+
+const makeRepo = (overrides: Partial<{
+  full_name: string
+  html_url: string
+  language: string | null
+  topics: string[]
+  description: string | null
+}> = {}) => ({
+  full_name: 'owner/repo',
+  html_url: 'https://github.com/owner/repo',
+  language: 'TypeScript',
+  topics: ['tooling'],
+  description: 'A great repo',
+  ...overrides,
+})
+
+const makeStar = (repoOverrides: Parameters<typeof makeRepo>[0] = {}): ActualStar => ({
+  starred_at: '2024-01-01T00:00:00Z',
+  repo: makeRepo(repoOverrides),
+})
+
+describe('mapStarToRaindrop', () => {
+  it('maps all fields correctly', () => {
+    const result = mapStarToRaindrop(makeStar(), '12345')
+    expect(result).toEqual({
+      collectionId: '12345',
+      title: 'owner/repo',
+      link: 'https://github.com/owner/repo',
+      tags: ['github', 'typescript', 'tooling'],
+      created: '2024-01-01T00:00:00Z',
+      excerpt: 'A great repo',
+    })
+  })
+
+  it('excludes null language from tags', () => {
+    const result = mapStarToRaindrop(makeStar({ language: null }), '12345')
+    expect(result.tags).toEqual(['github', 'tooling'])
+  })
+
+  it('handles empty topics', () => {
+    const result = mapStarToRaindrop(makeStar({ topics: [] }), '12345')
+    expect(result.tags).toEqual(['github', 'typescript'])
+  })
+
+  it('lowercases all tags', () => {
+    const result = mapStarToRaindrop(makeStar({ language: 'TypeScript', topics: ['MyTopic'] }), '12345')
+    expect(result.tags).toEqual(['github', 'typescript', 'mytopic'])
+  })
+
+  it('produces only github tag when language is null and topics is empty', () => {
+    const result = mapStarToRaindrop(makeStar({ language: null, topics: [] }), '12345')
+    expect(result.tags).toEqual(['github'])
+  })
+
+  it('passes collectionId through', () => {
+    expect(mapStarToRaindrop(makeStar(), 'my-collection').collectionId).toBe('my-collection')
+    expect(mapStarToRaindrop(makeStar(), undefined).collectionId).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests — expect them to fail**
+
+```bash
+npm test
+```
+
+Expected: Fails with an error like `SyntaxError: The requested module '../main.js' does not provide an export named 'mapStarToRaindrop'`.
+
+### Step 2b: Implement to make the tests pass
+
+- [ ] **Step 3: Add exported types and `mapStarToRaindrop` to `src/main.ts`**
+
+Replace the entire contents of `src/main.ts` with:
+
+```typescript
+import axios from "axios";
+import _ from "lodash";
+import { Octokit } from "octokit";
+
+const raindropAxios = axios.create({
+  baseURL: "https://api.raindrop.io/rest/v1",
+  headers: {
+    Authorization: `Bearer ${process.env.RAINDROP_TOKEN}`,
+    "Content-Type": "application/json",
+  },
+});
+
+export type StarredRepo = {
+  full_name: string;
+  html_url: string;
+  language: string | null;
+  topics?: string[];
+  description: string | null;
+};
+
+export type ActualStar = {
+  starred_at: string;
+  repo: StarredRepo;
+};
+
+export type RaindropItem = {
+  collectionId: string | undefined;
+  title: string;
+  link: string;
+  tags: string[];
+  created: string;
+  excerpt: string | null;
+};
+
+export function mapStarToRaindrop(
+  star: ActualStar,
+  collectionId: string | undefined
+): RaindropItem {
+  return {
+    collectionId,
+    title: star.repo.full_name,
+    link: star.repo.html_url,
+    tags: _([
+      "github",
+      star.repo.language || undefined,
+      ...(star.repo.topics || []),
+    ])
+      .compact()
+      .map((i) => i.toLowerCase())
+      .value(),
+    created: star.starred_at,
+    excerpt: star.repo.description,
+  };
+}
+
+export function filterNewRaindrops(
+  chunk: RaindropItem[],
+  duplicates: { link: string }[]
+): RaindropItem[] {
+  return chunk.filter((r) => duplicates.every((d) => d.link !== r.link));
+}
+
+export const main = async () => {
+  const octokit = new Octokit({ auth: process.env.GH_TOKEN });
+
+  console.log(new Date(), "Fetching all your starred repos...");
+  const stars = await octokit.paginate(
+    octokit.rest.activity.listReposStarredByAuthenticatedUser,
+    {
+      per_page: 100,
+      headers: {
+        accept: "application/vnd.github.v3.star+json",
+      },
+    }
+  );
+  console.log(new Date(), `Found ${stars.length} starred repos!`);
+
+  const newRaindrops = (stars as unknown as ActualStar[]).map((star) =>
+    mapStarToRaindrop(star, process.env.RAINDROP_COLLECTION_ID)
+  );
+  const chunks = _.chunk(newRaindrops, 100);
+
+  console.log(new Date(), `Looping through chunks of 100 repos...`);
+  for (const chunk of chunks) {
+    const existingUrlsRes = await raindropAxios.post("/import/url/exists", {
+      urls: chunk.map((s) => s.link),
+    });
+    const existingUrls = existingUrlsRes.data;
+    const toImport = filterNewRaindrops(chunk, existingUrls.duplicates);
+    if (toImport.length > 0) {
+      await raindropAxios.post("/raindrops", {
+        items: toImport,
+      });
+      console.log(new Date(), `Added ${toImport.length} stars to Raindrop`);
+    } else {
+      console.log(new Date(), `Skipped chunk (${chunk.length} repos)`);
+    }
+  }
+};
+```
+
+- [ ] **Step 4: Run the tests — expect `mapStarToRaindrop` tests to pass**
+
+```bash
+npm test
+```
+
+Expected: All 6 `mapStarToRaindrop` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.ts src/__tests__/main.unit.test.ts
+git commit -m "feat: extract mapStarToRaindrop with unit tests"
+```
+
+---
+
+## Task 3: Unit tests for `filterNewRaindrops` (TDD)
+
+**Files:**
+- Modify: `src/__tests__/main.unit.test.ts`
+
+- [ ] **Step 1: Replace `src/__tests__/main.unit.test.ts` with the complete file including `filterNewRaindrops` tests**
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { mapStarToRaindrop, filterNewRaindrops } from '../main.js'
+import type { ActualStar, RaindropItem } from '../main.js'
+
+const makeRepo = (overrides: Partial<{
+  full_name: string
+  html_url: string
+  language: string | null
+  topics: string[]
+  description: string | null
+}> = {}) => ({
+  full_name: 'owner/repo',
+  html_url: 'https://github.com/owner/repo',
+  language: 'TypeScript',
+  topics: ['tooling'],
+  description: 'A great repo',
+  ...overrides,
+})
+
+const makeStar = (repoOverrides: Parameters<typeof makeRepo>[0] = {}): ActualStar => ({
+  starred_at: '2024-01-01T00:00:00Z',
+  repo: makeRepo(repoOverrides),
+})
+
+describe('mapStarToRaindrop', () => {
+  it('maps all fields correctly', () => {
+    const result = mapStarToRaindrop(makeStar(), '12345')
+    expect(result).toEqual({
+      collectionId: '12345',
+      title: 'owner/repo',
+      link: 'https://github.com/owner/repo',
+      tags: ['github', 'typescript', 'tooling'],
+      created: '2024-01-01T00:00:00Z',
+      excerpt: 'A great repo',
+    })
+  })
+
+  it('excludes null language from tags', () => {
+    const result = mapStarToRaindrop(makeStar({ language: null }), '12345')
+    expect(result.tags).toEqual(['github', 'tooling'])
+  })
+
+  it('handles empty topics', () => {
+    const result = mapStarToRaindrop(makeStar({ topics: [] }), '12345')
+    expect(result.tags).toEqual(['github', 'typescript'])
+  })
+
+  it('lowercases all tags', () => {
+    const result = mapStarToRaindrop(makeStar({ language: 'TypeScript', topics: ['MyTopic'] }), '12345')
+    expect(result.tags).toEqual(['github', 'typescript', 'mytopic'])
+  })
+
+  it('produces only github tag when language is null and topics is empty', () => {
+    const result = mapStarToRaindrop(makeStar({ language: null, topics: [] }), '12345')
+    expect(result.tags).toEqual(['github'])
+  })
+
+  it('passes collectionId through', () => {
+    expect(mapStarToRaindrop(makeStar(), 'my-collection').collectionId).toBe('my-collection')
+    expect(mapStarToRaindrop(makeStar(), undefined).collectionId).toBeUndefined()
+  })
+})
+
+describe('filterNewRaindrops', () => {
+  const item = (link: string): RaindropItem => ({
+    collectionId: '1',
+    title: 'title',
+    link,
+    tags: [],
+    created: '',
+    excerpt: null,
+  })
+
+  it('returns all items when duplicates list is empty', () => {
+    const chunk = [item('https://a.com'), item('https://b.com')]
+    expect(filterNewRaindrops(chunk, [])).toEqual(chunk)
+  })
+
+  it('excludes items matching a duplicate link', () => {
+    const chunk = [item('https://a.com'), item('https://b.com')]
+    const result = filterNewRaindrops(chunk, [{ link: 'https://a.com' }])
+    expect(result).toEqual([item('https://b.com')])
+  })
+
+  it('returns empty array when all items are duplicates', () => {
+    const chunk = [item('https://a.com'), item('https://b.com')]
+    const result = filterNewRaindrops(chunk, [
+      { link: 'https://a.com' },
+      { link: 'https://b.com' },
+    ])
+    expect(result).toEqual([])
+  })
+
+  it('handles partial overlap correctly', () => {
+    const chunk = [item('https://a.com'), item('https://b.com'), item('https://c.com')]
+    const result = filterNewRaindrops(chunk, [{ link: 'https://b.com' }])
+    expect(result).toEqual([item('https://a.com'), item('https://c.com')])
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests — expect all 10 tests to pass**
+
+```bash
+npm test
+```
+
+Expected: All 10 tests pass (6 `mapStarToRaindrop` + 4 `filterNewRaindrops`). `filterNewRaindrops` is already implemented in Task 2's `src/main.ts` changes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/main.unit.test.ts
+git commit -m "feat: add filterNewRaindrops unit tests"
+```
+
+---
+
+## Task 4: Integration tests for `main()`
+
+**Files:**
+- Create: `src/__tests__/main.integration.test.ts`
+
+- [ ] **Step 1: Create `src/__tests__/main.integration.test.ts`**
+
+```typescript
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+const { mockPost, mockPaginate } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockPaginate: vi.fn(),
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    create: () => ({ post: mockPost }),
+  },
+}))
+
+vi.mock('octokit', () => ({
+  Octokit: vi.fn().mockImplementation(() => ({
+    paginate: mockPaginate,
+    rest: {
+      activity: {
+        listReposStarredByAuthenticatedUser: {},
+      },
+    },
+  })),
+}))
+
+import { main } from '../main.js'
+
+const makeStarResult = (name: string) => ({
+  starred_at: '2024-01-01T00:00:00Z',
+  repo: {
+    full_name: name,
+    html_url: `https://github.com/${name}`,
+    language: 'TypeScript',
+    topics: [],
+    description: null,
+  },
+})
+
+describe('main()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.RAINDROP_COLLECTION_ID = 'test-collection'
+    process.env.GH_TOKEN = 'test-gh-token'
+    process.env.RAINDROP_TOKEN = 'test-raindrop-token'
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('posts all repos when there are no duplicates', async () => {
+    const stars = [makeStarResult('owner/repo1'), makeStarResult('owner/repo2')]
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({ data: { duplicates: [] } })
+
+    await main()
+
+    expect(mockPost).toHaveBeenCalledWith('/import/url/exists', {
+      urls: ['https://github.com/owner/repo1', 'https://github.com/owner/repo2'],
+    })
+    expect(mockPost).toHaveBeenCalledWith('/raindrops', {
+      items: expect.arrayContaining([
+        expect.objectContaining({ link: 'https://github.com/owner/repo1' }),
+        expect.objectContaining({ link: 'https://github.com/owner/repo2' }),
+      ]),
+    })
+  })
+
+  it('does not post to /raindrops when all repos are duplicates', async () => {
+    const stars = [makeStarResult('owner/repo1'), makeStarResult('owner/repo2')]
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({
+      data: {
+        duplicates: [
+          { link: 'https://github.com/owner/repo1' },
+          { link: 'https://github.com/owner/repo2' },
+        ],
+      },
+    })
+
+    await main()
+
+    const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === '/raindrops')
+    expect(raindropsCalls).toHaveLength(0)
+  })
+
+  it('posts only non-duplicate repos', async () => {
+    const stars = [
+      makeStarResult('owner/repo1'),
+      makeStarResult('owner/repo2'),
+      makeStarResult('owner/repo3'),
+    ]
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({
+      data: { duplicates: [{ link: 'https://github.com/owner/repo2' }] },
+    })
+
+    await main()
+
+    const raindropsCall = mockPost.mock.calls.find((c) => c[0] === '/raindrops')
+    expect(raindropsCall![1].items).toHaveLength(2)
+    const links = raindropsCall![1].items.map((i: { link: string }) => i.link)
+    expect(links).not.toContain('https://github.com/owner/repo2')
+  })
+
+  it('splits 150 repos into two chunked POST /raindrops calls', async () => {
+    const stars = Array.from({ length: 150 }, (_, i) => makeStarResult(`owner/repo${i}`))
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({ data: { duplicates: [] } })
+
+    await main()
+
+    const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === '/raindrops')
+    expect(raindropsCalls).toHaveLength(2)
+    expect(raindropsCalls[0][1].items).toHaveLength(100)
+    expect(raindropsCalls[1][1].items).toHaveLength(50)
+  })
+
+  it('makes no Raindrop API calls when there are no starred repos', async () => {
+    mockPaginate.mockResolvedValue([])
+
+    await main()
+
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run all tests**
+
+```bash
+npm test
+```
+
+Expected: All 15 tests pass (10 unit + 5 integration). If any integration test fails, check that the `vi.hoisted()` block and `vi.mock()` factories are at the top of the file before any imports.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/__tests__/main.integration.test.ts
+git commit -m "feat: add integration tests for main() with mocked APIs"
+```
+
+---
+
+## Task 5: Add CI workflow
+
+**Files:**
+- Create: `.github/workflows/test.yml`
+
+- [ ] **Step 1: Create `.github/workflows/test.yml`**
+
+```yaml
+name: "Tests"
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - run: npm ci
+
+      - name: Run tests
+        run: npm test
+```
+
+- [ ] **Step 2: Verify all tests still pass locally**
+
+```bash
+npm test
+```
+
+Expected: All 15 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: add test workflow on push and pull_request"
+```

--- a/docs/superpowers/specs/2026-06-16-test-suite-design.md
+++ b/docs/superpowers/specs/2026-06-16-test-suite-design.md
@@ -1,0 +1,93 @@
+# Test Suite Design
+
+**Date:** 2026-06-16
+**Project:** starry-raindrop
+**Scope:** Add a Vitest-based test suite with unit and integration tests, wired into CI
+
+---
+
+## Context
+
+`starry-raindrop` is a small TypeScript/ESM tool that syncs GitHub starred repos to a Raindrop.io collection. All meaningful logic lives in `src/main.ts`. There are currently no tests.
+
+---
+
+## Architecture
+
+### Refactor: extract pure functions from `main()`
+
+`main.ts` currently inlines all logic inside one async function. Two pure functions are extracted to make unit testing possible:
+
+**`mapStarToRaindrop(star: ActualStar, collectionId: string): RaindropItem`**
+(`ActualStar` and `RaindropItem` are currently inline types in `main.ts` — they will be named and exported as part of this refactor so the extracted functions can reference them.)
+Converts a single GitHub starred repo into the Raindrop.io item format. Handles:
+- Field mapping: `full_name` → title, `html_url` → link, `starred_at` → created, `description` → excerpt
+- Tag pipeline: `["github", language, ...topics]`, compacted and lowercased via lodash
+
+**`filterNewRaindrops(chunk: RaindropItem[], duplicates: { link: string }[]): RaindropItem[]`**
+Given a chunk of raindrop items and the existing duplicates returned by the Raindrop API, returns only the items not already saved.
+
+`main()` is updated to call these functions instead of inlining the logic. Both are exported from `main.ts`.
+
+### Test file structure
+
+```
+src/
+  __tests__/
+    main.unit.test.ts       # unit tests for mapStarToRaindrop and filterNewRaindrops
+    main.integration.test.ts # integration tests for main() with mocked APIs
+```
+
+---
+
+## Unit Tests (`main.unit.test.ts`)
+
+Tests for `mapStarToRaindrop`:
+- Maps all fields correctly (title, link, created, excerpt, collectionId)
+- Tags include `"github"` + language + topics, all lowercased
+- Null/missing language is excluded from tags
+- Empty topics array produces just `["github"]`
+- Language with no topics produces `["github", "<language>"]`
+
+Tests for `filterNewRaindrops`:
+- Returns all items when duplicates list is empty
+- Excludes items whose link matches a duplicate
+- Returns empty array when all items are duplicates
+- Handles partial overlap (some duplicates, some new)
+
+---
+
+## Integration Tests (`main.integration.test.ts`)
+
+Mocking strategy:
+- `vi.mock('axios')` — intercepts `axios.create()`, controls `.post()` return values
+- `vi.mock('octokit')` — stubs `octokit.paginate()` return value
+- `process.env` vars (`GH_TOKEN`, `RAINDROP_TOKEN`, `RAINDROP_COLLECTION_ID`) set in test setup
+
+Test cases calling `main()`:
+- **Happy path — new repos**: 2 stars, no duplicates → `POST /raindrops` called once with both
+- **All duplicates**: 2 stars, both already exist → `POST /raindrops` never called
+- **Partial duplicates**: 3 stars, 1 duplicate → 2 items posted
+- **Chunking**: 150 stars → two `POST /raindrops` calls (chunks of 100 and 50)
+- **Empty stars**: 0 stars → no Raindrop API calls
+
+---
+
+## Framework
+
+**Vitest** — chosen for native ESM and TypeScript support with zero configuration. Jest-compatible API. Built-in `vi.mock()` for module mocking.
+
+Added to `package.json`:
+- `devDependencies`: `vitest`
+- `scripts.test`: `vitest run`
+
+---
+
+## CI
+
+New workflow: `.github/workflows/test.yml`
+- Triggers on `push` and `pull_request` (all branches)
+- Steps: `actions/checkout`, `actions/setup-node` (node-version-file: `.nvmrc`), `npm ci`, `npm test`
+- No secrets required — all API calls are mocked
+
+The existing `sync-stars.yml` (scheduled sync with real secrets) is unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
       "devDependencies": {
         "@types/node": "^22.19.21",
         "oxfmt": "^0.55.0",
-        "oxlint": "^1.70.0"
+        "oxlint": "^1.70.0",
+        "vitest": "^1.6.1"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -33,6 +34,386 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1048,6 +1429,337 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -1084,6 +1796,12 @@
       "integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
       "license": "MIT"
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
@@ -1097,6 +1815,75 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -1135,11 +1922,32 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1171,6 +1979,15 @@
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1184,6 +2001,36 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1195,6 +2042,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true
     },
     "node_modules/content-type": {
       "version": "2.0.0",
@@ -1215,6 +2068,20 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1230,6 +2097,18 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/delayed-stream": {
@@ -1248,6 +2127,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -1321,6 +2209,76 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -1357,6 +2315,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1364,6 +2336,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1401,6 +2382,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -1467,17 +2460,84 @@
         "node": ">= 6"
       }
     },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
+    },
     "node_modules/json-with-bigint": {
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
     },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -1493,6 +2553,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -1515,11 +2581,86 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/octokit": {
       "version": "5.0.5",
@@ -1541,6 +2682,21 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/oxfmt": {
@@ -1644,6 +2800,110 @@
         }
       }
     },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -1653,6 +2913,146 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "node_modules/tinypool": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
@@ -1661,6 +3061,15 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toad-cache": {
@@ -1715,6 +3124,15 @@
         }
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -1727,6 +3145,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -1752,6 +3176,192 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -1759,6 +3369,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "docker": "npm install && npm run build && docker compose up -d",
     "lint": "oxlint src",
     "format": "oxfmt src",
-    "format:check": "oxfmt --check src"
+    "format:check": "oxfmt --check src",
+    "test": "vitest run"
   },
   "repository": {
     "type": "git",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@types/node": "^22.19.21",
     "oxfmt": "^0.55.0",
-    "oxlint": "^1.70.0"
+    "oxlint": "^1.70.0",
+    "vitest": "^1.6.1"
   }
 }

--- a/src/__tests__/main.integration.test.ts
+++ b/src/__tests__/main.integration.test.ts
@@ -1,0 +1,122 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+const { mockPost, mockPaginate } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+  mockPaginate: vi.fn(),
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    create: () => ({ post: mockPost }),
+  },
+}))
+
+vi.mock('octokit', () => ({
+  Octokit: vi.fn().mockImplementation(() => ({
+    paginate: mockPaginate,
+    rest: {
+      activity: {
+        listReposStarredByAuthenticatedUser: {},
+      },
+    },
+  })),
+}))
+
+import { main } from '../main.js'
+
+const makeStarResult = (name: string) => ({
+  starred_at: '2024-01-01T00:00:00Z',
+  repo: {
+    full_name: name,
+    html_url: `https://github.com/${name}`,
+    language: 'TypeScript',
+    topics: [],
+    description: null,
+  },
+})
+
+describe('main()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.RAINDROP_COLLECTION_ID = 'test-collection'
+    process.env.GH_TOKEN = 'test-gh-token'
+    process.env.RAINDROP_TOKEN = 'test-raindrop-token'
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  it('posts all repos when there are no duplicates', async () => {
+    const stars = [makeStarResult('owner/repo1'), makeStarResult('owner/repo2')]
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({ data: { duplicates: [] } })
+
+    await main()
+
+    expect(mockPost).toHaveBeenCalledWith('/import/url/exists', {
+      urls: ['https://github.com/owner/repo1', 'https://github.com/owner/repo2'],
+    })
+    expect(mockPost).toHaveBeenCalledWith('/raindrops', {
+      items: expect.arrayContaining([
+        expect.objectContaining({ link: 'https://github.com/owner/repo1' }),
+        expect.objectContaining({ link: 'https://github.com/owner/repo2' }),
+      ]),
+    })
+  })
+
+  it('does not post to /raindrops when all repos are duplicates', async () => {
+    const stars = [makeStarResult('owner/repo1'), makeStarResult('owner/repo2')]
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({
+      data: {
+        duplicates: [
+          { link: 'https://github.com/owner/repo1' },
+          { link: 'https://github.com/owner/repo2' },
+        ],
+      },
+    })
+
+    await main()
+
+    const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === '/raindrops')
+    expect(raindropsCalls).toHaveLength(0)
+  })
+
+  it('posts only non-duplicate repos', async () => {
+    const stars = [
+      makeStarResult('owner/repo1'),
+      makeStarResult('owner/repo2'),
+      makeStarResult('owner/repo3'),
+    ]
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({
+      data: { duplicates: [{ link: 'https://github.com/owner/repo2' }] },
+    })
+
+    await main()
+
+    const raindropsCall = mockPost.mock.calls.find((c) => c[0] === '/raindrops')
+    expect(raindropsCall![1].items).toHaveLength(2)
+    const links = raindropsCall![1].items.map((i: { link: string }) => i.link)
+    expect(links).not.toContain('https://github.com/owner/repo2')
+  })
+
+  it('splits 150 repos into two chunked POST /raindrops calls', async () => {
+    const stars = Array.from({ length: 150 }, (_, i) => makeStarResult(`owner/repo${i}`))
+    mockPaginate.mockResolvedValue(stars)
+    mockPost.mockResolvedValue({ data: { duplicates: [] } })
+
+    await main()
+
+    const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === '/raindrops')
+    expect(raindropsCalls).toHaveLength(2)
+    expect(raindropsCalls[0][1].items).toHaveLength(100)
+    expect(raindropsCalls[1][1].items).toHaveLength(50)
+  })
+
+  it('makes no Raindrop API calls when there are no starred repos', async () => {
+    mockPaginate.mockResolvedValue([])
+
+    await main()
+
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/main.integration.test.ts
+++ b/src/__tests__/main.integration.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 
 const { mockPost, mockPaginate } = vi.hoisted(() => ({
   mockPost: vi.fn(),
@@ -36,12 +36,18 @@ const makeStarResult = (name: string) => ({
 })
 
 describe('main()', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(() => {
     vi.clearAllMocks()
     process.env.RAINDROP_COLLECTION_ID = 'test-collection'
     process.env.GH_TOKEN = 'test-gh-token'
     process.env.RAINDROP_TOKEN = 'test-raindrop-token'
-    vi.spyOn(console, 'log').mockImplementation(() => {})
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleSpy.mockRestore()
   })
 
   it('posts all repos when there are no duplicates', async () => {

--- a/src/__tests__/main.integration.test.ts
+++ b/src/__tests__/main.integration.test.ts
@@ -1,128 +1,128 @@
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 const { mockPost, mockPaginate } = vi.hoisted(() => ({
-  mockPost: vi.fn(),
-  mockPaginate: vi.fn(),
-}))
+	mockPost: vi.fn(),
+	mockPaginate: vi.fn(),
+}));
 
-vi.mock('axios', () => ({
-  default: {
-    create: () => ({ post: mockPost }),
-  },
-}))
+vi.mock("axios", () => ({
+	default: {
+		create: () => ({ post: mockPost }),
+	},
+}));
 
-vi.mock('octokit', () => ({
-  Octokit: vi.fn().mockImplementation(() => ({
-    paginate: mockPaginate,
-    rest: {
-      activity: {
-        listReposStarredByAuthenticatedUser: {},
-      },
-    },
-  })),
-}))
+vi.mock("octokit", () => ({
+	Octokit: vi.fn().mockImplementation(() => ({
+		paginate: mockPaginate,
+		rest: {
+			activity: {
+				listReposStarredByAuthenticatedUser: {},
+			},
+		},
+	})),
+}));
 
-import { main } from '../main.js'
+import { main } from "../main.js";
 
 const makeStarResult = (name: string) => ({
-  starred_at: '2024-01-01T00:00:00Z',
-  repo: {
-    full_name: name,
-    html_url: `https://github.com/${name}`,
-    language: 'TypeScript',
-    topics: [],
-    description: null,
-  },
-})
+	starred_at: "2024-01-01T00:00:00Z",
+	repo: {
+		full_name: name,
+		html_url: `https://github.com/${name}`,
+		language: "TypeScript",
+		topics: [],
+		description: null,
+	},
+});
 
-describe('main()', () => {
-  let consoleSpy: ReturnType<typeof vi.spyOn>
+describe("main()", () => {
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
-    vi.clearAllMocks()
-    process.env.RAINDROP_COLLECTION_ID = 'test-collection'
-    process.env.GH_TOKEN = 'test-gh-token'
-    process.env.RAINDROP_TOKEN = 'test-raindrop-token'
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-  })
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env.RAINDROP_COLLECTION_ID = "test-collection";
+		process.env.GH_TOKEN = "test-gh-token";
+		process.env.RAINDROP_TOKEN = "test-raindrop-token";
+		consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	});
 
-  afterEach(() => {
-    consoleSpy.mockRestore()
-  })
+	afterEach(() => {
+		consoleSpy.mockRestore();
+	});
 
-  it('posts all repos when there are no duplicates', async () => {
-    const stars = [makeStarResult('owner/repo1'), makeStarResult('owner/repo2')]
-    mockPaginate.mockResolvedValue(stars)
-    mockPost.mockResolvedValue({ data: { duplicates: [] } })
+	it("posts all repos when there are no duplicates", async () => {
+		const stars = [makeStarResult("owner/repo1"), makeStarResult("owner/repo2")];
+		mockPaginate.mockResolvedValue(stars);
+		mockPost.mockResolvedValue({ data: { duplicates: [] } });
 
-    await main()
+		await main();
 
-    expect(mockPost).toHaveBeenCalledWith('/import/url/exists', {
-      urls: ['https://github.com/owner/repo1', 'https://github.com/owner/repo2'],
-    })
-    expect(mockPost).toHaveBeenCalledWith('/raindrops', {
-      items: expect.arrayContaining([
-        expect.objectContaining({ link: 'https://github.com/owner/repo1' }),
-        expect.objectContaining({ link: 'https://github.com/owner/repo2' }),
-      ]),
-    })
-  })
+		expect(mockPost).toHaveBeenCalledWith("/import/url/exists", {
+			urls: ["https://github.com/owner/repo1", "https://github.com/owner/repo2"],
+		});
+		expect(mockPost).toHaveBeenCalledWith("/raindrops", {
+			items: expect.arrayContaining([
+				expect.objectContaining({ link: "https://github.com/owner/repo1" }),
+				expect.objectContaining({ link: "https://github.com/owner/repo2" }),
+			]),
+		});
+	});
 
-  it('does not post to /raindrops when all repos are duplicates', async () => {
-    const stars = [makeStarResult('owner/repo1'), makeStarResult('owner/repo2')]
-    mockPaginate.mockResolvedValue(stars)
-    mockPost.mockResolvedValue({
-      data: {
-        duplicates: [
-          { link: 'https://github.com/owner/repo1' },
-          { link: 'https://github.com/owner/repo2' },
-        ],
-      },
-    })
+	it("does not post to /raindrops when all repos are duplicates", async () => {
+		const stars = [makeStarResult("owner/repo1"), makeStarResult("owner/repo2")];
+		mockPaginate.mockResolvedValue(stars);
+		mockPost.mockResolvedValue({
+			data: {
+				duplicates: [
+					{ link: "https://github.com/owner/repo1" },
+					{ link: "https://github.com/owner/repo2" },
+				],
+			},
+		});
 
-    await main()
+		await main();
 
-    const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === '/raindrops')
-    expect(raindropsCalls).toHaveLength(0)
-  })
+		const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === "/raindrops");
+		expect(raindropsCalls).toHaveLength(0);
+	});
 
-  it('posts only non-duplicate repos', async () => {
-    const stars = [
-      makeStarResult('owner/repo1'),
-      makeStarResult('owner/repo2'),
-      makeStarResult('owner/repo3'),
-    ]
-    mockPaginate.mockResolvedValue(stars)
-    mockPost.mockResolvedValue({
-      data: { duplicates: [{ link: 'https://github.com/owner/repo2' }] },
-    })
+	it("posts only non-duplicate repos", async () => {
+		const stars = [
+			makeStarResult("owner/repo1"),
+			makeStarResult("owner/repo2"),
+			makeStarResult("owner/repo3"),
+		];
+		mockPaginate.mockResolvedValue(stars);
+		mockPost.mockResolvedValue({
+			data: { duplicates: [{ link: "https://github.com/owner/repo2" }] },
+		});
 
-    await main()
+		await main();
 
-    const raindropsCall = mockPost.mock.calls.find((c) => c[0] === '/raindrops')
-    expect(raindropsCall![1].items).toHaveLength(2)
-    const links = raindropsCall![1].items.map((i: { link: string }) => i.link)
-    expect(links).not.toContain('https://github.com/owner/repo2')
-  })
+		const raindropsCall = mockPost.mock.calls.find((c) => c[0] === "/raindrops");
+		expect(raindropsCall![1].items).toHaveLength(2);
+		const links = raindropsCall![1].items.map((i: { link: string }) => i.link);
+		expect(links).not.toContain("https://github.com/owner/repo2");
+	});
 
-  it('splits 150 repos into two chunked POST /raindrops calls', async () => {
-    const stars = Array.from({ length: 150 }, (_, i) => makeStarResult(`owner/repo${i}`))
-    mockPaginate.mockResolvedValue(stars)
-    mockPost.mockResolvedValue({ data: { duplicates: [] } })
+	it("splits 150 repos into two chunked POST /raindrops calls", async () => {
+		const stars = Array.from({ length: 150 }, (_, i) => makeStarResult(`owner/repo${i}`));
+		mockPaginate.mockResolvedValue(stars);
+		mockPost.mockResolvedValue({ data: { duplicates: [] } });
 
-    await main()
+		await main();
 
-    const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === '/raindrops')
-    expect(raindropsCalls).toHaveLength(2)
-    expect(raindropsCalls[0][1].items).toHaveLength(100)
-    expect(raindropsCalls[1][1].items).toHaveLength(50)
-  })
+		const raindropsCalls = mockPost.mock.calls.filter((c) => c[0] === "/raindrops");
+		expect(raindropsCalls).toHaveLength(2);
+		expect(raindropsCalls[0][1].items).toHaveLength(100);
+		expect(raindropsCalls[1][1].items).toHaveLength(50);
+	});
 
-  it('makes no Raindrop API calls when there are no starred repos', async () => {
-    mockPaginate.mockResolvedValue([])
+	it("makes no Raindrop API calls when there are no starred repos", async () => {
+		mockPaginate.mockResolvedValue([]);
 
-    await main()
+		await main();
 
-    expect(mockPost).not.toHaveBeenCalled()
-  })
-})
+		expect(mockPost).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/main.unit.test.ts
+++ b/src/__tests__/main.unit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { mapStarToRaindrop } from '../main.js'
+import type { ActualStar } from '../main.js'
+
+const makeRepo = (overrides: Partial<{
+  full_name: string
+  html_url: string
+  language: string | null
+  topics: string[]
+  description: string | null
+}> = {}) => ({
+  full_name: 'owner/repo',
+  html_url: 'https://github.com/owner/repo',
+  language: 'TypeScript',
+  topics: ['tooling'],
+  description: 'A great repo',
+  ...overrides,
+})
+
+const makeStar = (repoOverrides: Parameters<typeof makeRepo>[0] = {}): ActualStar => ({
+  starred_at: '2024-01-01T00:00:00Z',
+  repo: makeRepo(repoOverrides),
+})
+
+describe('mapStarToRaindrop', () => {
+  it('maps all fields correctly', () => {
+    const result = mapStarToRaindrop(makeStar(), '12345')
+    expect(result).toEqual({
+      collectionId: '12345',
+      title: 'owner/repo',
+      link: 'https://github.com/owner/repo',
+      tags: ['github', 'typescript', 'tooling'],
+      created: '2024-01-01T00:00:00Z',
+      excerpt: 'A great repo',
+    })
+  })
+
+  it('excludes null language from tags', () => {
+    const result = mapStarToRaindrop(makeStar({ language: null }), '12345')
+    expect(result.tags).toEqual(['github', 'tooling'])
+  })
+
+  it('handles empty topics', () => {
+    const result = mapStarToRaindrop(makeStar({ topics: [] }), '12345')
+    expect(result.tags).toEqual(['github', 'typescript'])
+  })
+
+  it('lowercases all tags', () => {
+    const result = mapStarToRaindrop(makeStar({ language: 'TypeScript', topics: ['MyTopic'] }), '12345')
+    expect(result.tags).toEqual(['github', 'typescript', 'mytopic'])
+  })
+
+  it('produces only github tag when language is null and topics is empty', () => {
+    const result = mapStarToRaindrop(makeStar({ language: null, topics: [] }), '12345')
+    expect(result.tags).toEqual(['github'])
+  })
+
+  it('passes collectionId through', () => {
+    expect(mapStarToRaindrop(makeStar(), 'my-collection').collectionId).toBe('my-collection')
+    expect(mapStarToRaindrop(makeStar(), undefined).collectionId).toBeUndefined()
+  })
+})

--- a/src/__tests__/main.unit.test.ts
+++ b/src/__tests__/main.unit.test.ts
@@ -1,102 +1,107 @@
-import { describe, it, expect } from 'vitest'
-import { mapStarToRaindrop, filterNewRaindrops } from '../main.js'
-import type { ActualStar, RaindropItem } from '../main.js'
+import { describe, it, expect } from "vitest";
+import { mapStarToRaindrop, filterNewRaindrops } from "../main.js";
+import type { ActualStar, RaindropItem } from "../main.js";
 
-const makeRepo = (overrides: Partial<{
-  full_name: string
-  html_url: string
-  language: string | null
-  topics: string[]
-  description: string | null
-}> = {}) => ({
-  full_name: 'owner/repo',
-  html_url: 'https://github.com/owner/repo',
-  language: 'TypeScript',
-  topics: ['tooling'],
-  description: 'A great repo',
-  ...overrides,
-})
+const makeRepo = (
+	overrides: Partial<{
+		full_name: string;
+		html_url: string;
+		language: string | null;
+		topics: string[];
+		description: string | null;
+	}> = {},
+) => ({
+	full_name: "owner/repo",
+	html_url: "https://github.com/owner/repo",
+	language: "TypeScript",
+	topics: ["tooling"],
+	description: "A great repo",
+	...overrides,
+});
 
 const makeStar = (repoOverrides: Parameters<typeof makeRepo>[0] = {}): ActualStar => ({
-  starred_at: '2024-01-01T00:00:00Z',
-  repo: makeRepo(repoOverrides),
-})
+	starred_at: "2024-01-01T00:00:00Z",
+	repo: makeRepo(repoOverrides),
+});
 
-describe('mapStarToRaindrop', () => {
-  it('maps all fields correctly', () => {
-    const result = mapStarToRaindrop(makeStar(), '12345')
-    expect(result).toEqual({
-      collectionId: '12345',
-      title: 'owner/repo',
-      link: 'https://github.com/owner/repo',
-      tags: ['github', 'typescript', 'tooling'],
-      created: '2024-01-01T00:00:00Z',
-      excerpt: 'A great repo',
-    })
-  })
+describe("mapStarToRaindrop", () => {
+	it("maps all fields correctly", () => {
+		const result = mapStarToRaindrop(makeStar(), "12345");
+		expect(result).toEqual({
+			collectionId: "12345",
+			title: "owner/repo",
+			link: "https://github.com/owner/repo",
+			tags: ["github", "typescript", "tooling"],
+			created: "2024-01-01T00:00:00Z",
+			excerpt: "A great repo",
+		});
+	});
 
-  it('excludes null language from tags', () => {
-    const result = mapStarToRaindrop(makeStar({ language: null }), '12345')
-    expect(result.tags).toEqual(['github', 'tooling'])
-  })
+	it("excludes null language from tags", () => {
+		const result = mapStarToRaindrop(makeStar({ language: null }), "12345");
+		expect(result.tags).toEqual(["github", "tooling"]);
+	});
 
-  it('handles empty topics', () => {
-    const result = mapStarToRaindrop(makeStar({ topics: [] }), '12345')
-    expect(result.tags).toEqual(['github', 'typescript'])
-  })
+	it("handles empty topics", () => {
+		const result = mapStarToRaindrop(makeStar({ topics: [] }), "12345");
+		expect(result.tags).toEqual(["github", "typescript"]);
+	});
 
-  it('lowercases all tags', () => {
-    const result = mapStarToRaindrop(makeStar({ language: 'TypeScript', topics: ['MyTopic'] }), '12345')
-    expect(result.tags).toEqual(['github', 'typescript', 'mytopic'])
-  })
+	it("lowercases all tags", () => {
+		const result = mapStarToRaindrop(
+			makeStar({ language: "TypeScript", topics: ["MyTopic"] }),
+			"12345",
+		);
+		expect(result.tags).toEqual(["github", "typescript", "mytopic"]);
+	});
 
-  it('produces only github tag when language is null and topics is empty', () => {
-    const result = mapStarToRaindrop(makeStar({ language: null, topics: [] }), '12345')
-    expect(result.tags).toEqual(['github'])
-  })
+	it("produces only github tag when language is null and topics is empty", () => {
+		const result = mapStarToRaindrop(makeStar({ language: null, topics: [] }), "12345");
+		expect(result.tags).toEqual(["github"]);
+	});
 
-  it('passes string collectionId through', () => {
-    expect(mapStarToRaindrop(makeStar(), 'my-collection').collectionId).toBe('my-collection')
-  })
+	it("passes string collectionId through", () => {
+		expect(mapStarToRaindrop(makeStar(), "my-collection").collectionId).toBe("my-collection");
+	});
 
-  it('passes undefined collectionId through', () => {
-    expect(mapStarToRaindrop(makeStar(), undefined).collectionId).toBeUndefined()
-  })
-})
+	it("passes undefined collectionId through", () => {
+		expect(mapStarToRaindrop(makeStar(), undefined).collectionId).toBeUndefined();
+	});
+});
 
-describe('filterNewRaindrops', () => {
-  const item = (link: string): RaindropItem => ({
-    collectionId: '1',
-    title: 'title',
-    link,
-    tags: [],
-    created: '',
-    excerpt: null,
-  })
+describe("filterNewRaindrops", () => {
+	const item = (link: string): RaindropItem => ({
+		collectionId: "1",
+		title: "title",
+		link,
+		tags: [],
+		created: "",
+		excerpt: null,
+	});
 
-  it('returns all items when duplicates list is empty', () => {
-    const chunk = [item('https://a.com'), item('https://b.com')]
-    expect(filterNewRaindrops(chunk, [])).toEqual(chunk)
-  })
+	it("returns all items when duplicates list is empty", () => {
+		const chunk = [item("https://a.com"), item("https://b.com")];
+		expect(filterNewRaindrops(chunk, [])).toEqual(chunk);
+	});
 
-  it('excludes items matching a duplicate link', () => {
-    const chunk = [item('https://a.com'), item('https://b.com')]
-    const result = filterNewRaindrops(chunk, [{ link: 'https://a.com' }])
-    expect(result).toEqual([item('https://b.com')])
-  })
+	it("excludes items matching a duplicate link", () => {
+		const chunk = [item("https://a.com"), item("https://b.com")];
+		const result = filterNewRaindrops(chunk, [{ link: "https://a.com" }]);
+		expect(result).toEqual([item("https://b.com")]);
+	});
 
-  it('returns empty array when all items are duplicates', () => {
-    const chunk = [item('https://a.com'), item('https://b.com')]
-    const result = filterNewRaindrops(chunk, [
-      { link: 'https://a.com' },
-      { link: 'https://b.com' },
-    ])
-    expect(result).toEqual([])
-  })
+	it("returns empty array when all items are duplicates", () => {
+		const chunk = [item("https://a.com"), item("https://b.com")];
+		const result = filterNewRaindrops(chunk, [
+			{ link: "https://a.com" },
+			{ link: "https://b.com" },
+		]);
+		expect(result).toEqual([]);
+	});
 
-  it('handles partial overlap correctly', () => {
-    const chunk = [item('https://a.com'), item('https://b.com'), item('https://c.com')]
-    const result = filterNewRaindrops(chunk, [{ link: 'https://b.com' }])
-    expect(result).toEqual([item('https://a.com'), item('https://c.com')])
-  })
-})
+	it("handles partial overlap correctly", () => {
+		const chunk = [item("https://a.com"), item("https://b.com"), item("https://c.com")];
+		const result = filterNewRaindrops(chunk, [{ link: "https://b.com" }]);
+		expect(result).toEqual([item("https://a.com"), item("https://c.com")]);
+	});
+});

--- a/src/__tests__/main.unit.test.ts
+++ b/src/__tests__/main.unit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { mapStarToRaindrop } from '../main.js'
-import type { ActualStar } from '../main.js'
+import { mapStarToRaindrop, filterNewRaindrops } from '../main.js'
+import type { ActualStar, RaindropItem } from '../main.js'
 
 const makeRepo = (overrides: Partial<{
   full_name: string
@@ -58,5 +58,42 @@ describe('mapStarToRaindrop', () => {
   it('passes collectionId through', () => {
     expect(mapStarToRaindrop(makeStar(), 'my-collection').collectionId).toBe('my-collection')
     expect(mapStarToRaindrop(makeStar(), undefined).collectionId).toBeUndefined()
+  })
+})
+
+describe('filterNewRaindrops', () => {
+  const item = (link: string): RaindropItem => ({
+    collectionId: '1',
+    title: 'title',
+    link,
+    tags: [],
+    created: '',
+    excerpt: null,
+  })
+
+  it('returns all items when duplicates list is empty', () => {
+    const chunk = [item('https://a.com'), item('https://b.com')]
+    expect(filterNewRaindrops(chunk, [])).toEqual(chunk)
+  })
+
+  it('excludes items matching a duplicate link', () => {
+    const chunk = [item('https://a.com'), item('https://b.com')]
+    const result = filterNewRaindrops(chunk, [{ link: 'https://a.com' }])
+    expect(result).toEqual([item('https://b.com')])
+  })
+
+  it('returns empty array when all items are duplicates', () => {
+    const chunk = [item('https://a.com'), item('https://b.com')]
+    const result = filterNewRaindrops(chunk, [
+      { link: 'https://a.com' },
+      { link: 'https://b.com' },
+    ])
+    expect(result).toEqual([])
+  })
+
+  it('handles partial overlap correctly', () => {
+    const chunk = [item('https://a.com'), item('https://b.com'), item('https://c.com')]
+    const result = filterNewRaindrops(chunk, [{ link: 'https://b.com' }])
+    expect(result).toEqual([item('https://a.com'), item('https://c.com')])
   })
 })

--- a/src/__tests__/main.unit.test.ts
+++ b/src/__tests__/main.unit.test.ts
@@ -55,8 +55,11 @@ describe('mapStarToRaindrop', () => {
     expect(result.tags).toEqual(['github'])
   })
 
-  it('passes collectionId through', () => {
+  it('passes string collectionId through', () => {
     expect(mapStarToRaindrop(makeStar(), 'my-collection').collectionId).toBe('my-collection')
+  })
+
+  it('passes undefined collectionId through', () => {
     expect(mapStarToRaindrop(makeStar(), undefined).collectionId).toBeUndefined()
   })
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,56 @@ const raindropAxios = axios.create({
 	},
 });
 
+export type StarredRepo = {
+  full_name: string;
+  html_url: string;
+  language: string | null;
+  topics?: string[];
+  description: string | null;
+};
+
+export type ActualStar = {
+  starred_at: string;
+  repo: StarredRepo;
+};
+
+export type RaindropItem = {
+  collectionId: string | undefined;
+  title: string;
+  link: string;
+  tags: string[];
+  created: string;
+  excerpt: string | null;
+};
+
+export function mapStarToRaindrop(
+  star: ActualStar,
+  collectionId: string | undefined
+): RaindropItem {
+  return {
+    collectionId,
+    title: star.repo.full_name,
+    link: star.repo.html_url,
+    tags: _([
+      "github",
+      star.repo.language || undefined,
+      ...(star.repo.topics || []),
+    ])
+      .compact()
+      .map((i) => i.toLowerCase())
+      .value(),
+    created: star.starred_at,
+    excerpt: star.repo.description,
+  };
+}
+
+export function filterNewRaindrops(
+  chunk: RaindropItem[],
+  duplicates: { link: string }[]
+): RaindropItem[] {
+  return chunk.filter((r) => duplicates.every((d) => d.link !== r.link));
+}
+
 export const main = async () => {
 	const octokit = new Octokit({ auth: process.env.GH_TOKEN });
 
@@ -24,22 +74,9 @@ export const main = async () => {
 	});
 	console.log(new Date(), `Found ${stars.length} starred repos!`);
 
-	// Since we passed a custom header, the types aren't accurate anymore
-	type ActualStar = { starred_at: string; repo: (typeof stars)[number] };
-
-	const newRaindrops = (stars as unknown as ActualStar[]).map((star) => {
-		return {
-			collectionId: process.env.RAINDROP_COLLECTION_ID,
-			title: star.repo.full_name,
-			link: star.repo.html_url,
-			tags: _(["github", star.repo.language || undefined, ...(star.repo.topics || [])])
-				.compact()
-				.map((i) => i.toLowerCase())
-				.value(),
-			created: star.starred_at,
-			excerpt: star.repo.description,
-		};
-	});
+	const newRaindrops = (stars as unknown as ActualStar[]).map((star) =>
+		mapStarToRaindrop(star, process.env.RAINDROP_COLLECTION_ID)
+	);
 	const chunks = _.chunk(newRaindrops, 100);
 
 	console.log(new Date(), `Looping through chunks of 100 repos...`);
@@ -48,9 +85,7 @@ export const main = async () => {
 			urls: chunk.map((s) => s.link),
 		});
 		const existingUrls = existingUrlsRes.data;
-		const toImport = chunk.filter((r) => {
-			return existingUrls.duplicates.every((d: any) => d.link !== r.link);
-		});
+		const toImport = filterNewRaindrops(chunk, existingUrls.duplicates);
 		if (toImport.length > 0) {
 			await raindropAxios.post("/raindrops", {
 				items: toImport,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,53 +11,49 @@ const raindropAxios = axios.create({
 });
 
 export type StarredRepo = {
-  full_name: string;
-  html_url: string;
-  language: string | null;
-  topics?: string[];
-  description: string | null;
+	full_name: string;
+	html_url: string;
+	language: string | null;
+	topics?: string[];
+	description: string | null;
 };
 
 export type ActualStar = {
-  starred_at: string;
-  repo: StarredRepo;
+	starred_at: string;
+	repo: StarredRepo;
 };
 
 export type RaindropItem = {
-  collectionId: string | undefined;
-  title: string;
-  link: string;
-  tags: string[];
-  created: string;
-  excerpt: string | null;
+	collectionId: string | undefined;
+	title: string;
+	link: string;
+	tags: string[];
+	created: string;
+	excerpt: string | null;
 };
 
 export function mapStarToRaindrop(
-  star: ActualStar,
-  collectionId: string | undefined
+	star: ActualStar,
+	collectionId: string | undefined,
 ): RaindropItem {
-  return {
-    collectionId,
-    title: star.repo.full_name,
-    link: star.repo.html_url,
-    tags: _([
-      "github",
-      star.repo.language || undefined,
-      ...(star.repo.topics || []),
-    ])
-      .compact()
-      .map((i) => i.toLowerCase())
-      .value(),
-    created: star.starred_at,
-    excerpt: star.repo.description,
-  };
+	return {
+		collectionId,
+		title: star.repo.full_name,
+		link: star.repo.html_url,
+		tags: _(["github", star.repo.language || undefined, ...(star.repo.topics || [])])
+			.compact()
+			.map((i) => i.toLowerCase())
+			.value(),
+		created: star.starred_at,
+		excerpt: star.repo.description,
+	};
 }
 
 export function filterNewRaindrops(
-  chunk: RaindropItem[],
-  duplicates: { link: string }[]
+	chunk: RaindropItem[],
+	duplicates: { link: string }[],
 ): RaindropItem[] {
-  return chunk.filter((r) => duplicates.every((d) => d.link !== r.link));
+	return chunk.filter((r) => duplicates.every((d) => d.link !== r.link));
 }
 
 export const main = async () => {
@@ -75,7 +71,7 @@ export const main = async () => {
 	console.log(new Date(), `Found ${stars.length} starred repos!`);
 
 	const newRaindrops = (stars as unknown as ActualStar[]).map((star) =>
-		mapStarToRaindrop(star, process.env.RAINDROP_COLLECTION_ID)
+		mapStarToRaindrop(star, process.env.RAINDROP_COLLECTION_ID),
 	);
 	const chunks = _.chunk(newRaindrops, 100);
 


### PR DESCRIPTION
## Summary

- Extracts `mapStarToRaindrop` and `filterNewRaindrops` as exported pure functions from `main()`, along with named types (`StarredRepo`, `ActualStar`, `RaindropItem`), enabling unit testing without touching real APIs
- Adds 11 unit tests covering both pure functions (tag pipeline, deduplication, field mapping, collectionId passthrough)
- Adds 5 integration tests for `main()` with fully mocked axios and Octokit (happy path, all-duplicates, partial duplicates, chunking at 150 repos, empty stars)
- Adds `.github/workflows/test.yml` that runs `npm test` on every push and PR — no secrets required since all API calls are mocked

## Test Plan

- [ ] `npm test` passes locally (16 tests: 11 unit + 5 integration)
- [ ] CI workflow triggers on push/PR and passes on GitHub Actions
- [ ] Existing `sync-stars.yml` workflow is unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)